### PR TITLE
Remove execFilePath method

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -37,16 +37,6 @@ module.exports = Helpers =
       spawnedProcess.on 'close', ->
         resolve(data.join(''))
 
-  # This should only be used if the linter is only working with files in their
-  #   base directory. Else wise they should use `Helpers#exec`.
-  execFilePath: (command, args = [], filePath, options = {}) ->
-    throw new Error "Nothing to execute." unless arguments.length
-    throw new Error "No File Path to work with." unless filePath
-    return new Promise (resolve) ->
-      options.cwd = path.dirname(filePath) unless options.cwd
-      args.push(filePath)
-      resolve(Helpers.exec(command, args, options))
-
   # Due to what we are attempting to do, the only viable solution right now is
   #   XRegExp.
   #

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -37,21 +37,6 @@ describe 'linter helpers', ->
       waitsForPromise ->
         helpers.execNode(__dirname + '/fixtures/something.js', ['input'], {stream: 'stdout', stdin: 'Wow'}).then (data) ->
           expect(data).toBe('STDOUTWow')
-  describe '::execFilePath', ->
-    it 'cries when no argument is passed', ->
-      expect ->
-        helpers.execFilePath()
-      .toThrow()
-    it 'cries when no filepath is passed', ->
-      gotError = false
-      try
-        helpers.execFilePath('cat', [])
-      catch erro then gotError = true
-      expect(gotError).toBe(true)
-    it 'works', ->
-      waitsForPromise ->
-        helpers.execFilePath('cat', [], testFile).then (text) ->
-          expect(text).toBe(testContents)
   describe '::parse', ->
     it 'cries when no argument is passed', ->
       expect ->


### PR DESCRIPTION
Fixes #4 
/cc @atom-community/linter-contributors
/cc @AtomLinter/linter 
/cc @AtomLinter/owners 
This is an API breaking change, make sure you are not using this method anywhere.