### PR TITLE
Fixed linter on windows machines

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -31,8 +31,10 @@ module.exports = Helpers =
         else
           resolve(data.stderr.join(''))
       if isNodeExecutable
-        options.env = JSON.parse(JSON.stringify(process.env))
-        delete options.env.OS
+        options.env ?= {}
+        for prop in process.env
+          if process.env.hasOwnProperty(prop) and prop isnt 'OS'
+            options.env[prop] = process.env[prop]
         spawnedProcess = new BufferedNodeProcess({command, args, options, stdout, stderr, exit})
       else
         spawnedProcess = new BufferedProcess({command, args, stdout, stderr, exit})

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -31,7 +31,9 @@ module.exports = Helpers =
         else
           resolve(data.stderr.join(''))
       if isNodeExecutable
-        spawnedProcess = new BufferedNodeProcess({command, args, stdout, stderr, exit})
+        options.env = JSON.parse(JSON.stringify(process.env))
+        delete options.env.OS
+        spawnedProcess = new BufferedNodeProcess({command, args, options, stdout, stderr, exit})
       else
         spawnedProcess = new BufferedProcess({command, args, stdout, stderr, exit})
       spawnedProcess.onWillThrowError(reject)


### PR DESCRIPTION
Passing in custom options without process.env.OS to fix issues on windows machines.

I'm creating a copy of the process.env by using JSON.parse(JSON.stringify(process.env)), which is a bit ugly. I can change that if you know of a cleaner way to do it.