### PR TITLE
Pass options to BufferedProcess

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -37,7 +37,7 @@ module.exports = Helpers =
           options.env[prop] = value unless prop is 'OS'
         spawnedProcess = new BufferedNodeProcess({command, args, options, stdout, stderr, exit})
       else
-        spawnedProcess = new BufferedProcess({command, args, stdout, stderr, exit})
+        spawnedProcess = new BufferedProcess({command, args, options, stdout, stderr, exit})
       spawnedProcess.onWillThrowError(reject)
       if options.stdin
         spawnedProcess.process.stdin.write(options.stdin.toString())

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -107,3 +107,10 @@ describe 'linter helpers', ->
       .toThrow()
     it 'works', ->
       expect(helpers.findFile(__dirname, 'package.json')).toBe(fs.realpathSync("#{__dirname}/../package.json"))
+
+  describe '::exec options', ->
+    it 'honors cwd option', ->
+      waitsForPromise ->
+        testDir = "#{__dirname}/fixtures"
+        helpers.exec( 'pwd', [], {cwd: testDir} ).then (result) ->
+          expect(result.trim()).toEqual(testDir)


### PR DESCRIPTION
Pass the `options` object along to `BufferedProcess`.  

 - Fixes #28 