### PR TITLE
accept optional start of column for rangeFromLineNumber

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -48,11 +48,13 @@ module.exports = Helpers =
         spawnedProcess.process.stdin.write(options.stdin.toString())
         spawnedProcess.process.stdin.end() # We have to end it or the programs will keep waiting forever
 
-  rangeFromLineNumber: (textEditor, lineNumber) ->
+  rangeFromLineNumber: (textEditor, lineNumber, colStart) ->
     throw new Error('Provided text editor is invalid') unless textEditor instanceof TextEditor
     throw new Error('Invalid lineNumber provided') if typeof lineNumber is 'undefined'
+    unless typeof colStart is 'number'
+      colStart = (textEditor.indentationForBufferRow(lineNumber) * textEditor.getTabLength())
     return [
-      [lineNumber, (textEditor.indentationForBufferRow(lineNumber) * textEditor.getTabLength())],
+      [lineNumber, colStart],
       [lineNumber, textEditor.getBuffer().lineLengthForRow(lineNumber)]
     ]
 

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -83,7 +83,19 @@ describe 'linter helpers', ->
           expect(range[0][1]).toEqual(0)
           expect(range[1][0]).toEqual(1)
           expect(range[1][1]).toEqual(41)
-
+    it 'returns a range (array) with some valid points and provided colStart', ->
+      waitsForPromise ->
+        atom.workspace.open("#{__dirname}/fixtures/something.js").then ->
+          textEditor = atom.workspace.getActiveTextEditor()
+          range = helpers.rangeFromLineNumber(textEditor, 1) # 0 indexed
+          colStart = 4
+          expect(range instanceof Array).toBe(true)
+          expect(range[0] instanceof Array).toBe(true)
+          expect(range[1] instanceof Array).toBe(true)
+          expect(range[0][0]).toEqual(1)
+          expect(range[0][1]).toEqual(4)
+          expect(range[1][0]).toEqual(1)
+          expect(range[1][1]).toEqual(41)
   describe '::parse', ->
     it 'cries when no argument is passed', ->
       expect ->

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -87,8 +87,7 @@ describe 'linter helpers', ->
       waitsForPromise ->
         atom.workspace.open("#{__dirname}/fixtures/something.js").then ->
           textEditor = atom.workspace.getActiveTextEditor()
-          range = helpers.rangeFromLineNumber(textEditor, 1) # 0 indexed
-          colStart = 4
+          range = helpers.rangeFromLineNumber(textEditor, 1, 4) # 0 indexed
           expect(range instanceof Array).toBe(true)
           expect(range[0] instanceof Array).toBe(true)
           expect(range[1] instanceof Array).toBe(true)
@@ -96,6 +95,7 @@ describe 'linter helpers', ->
           expect(range[0][1]).toEqual(4)
           expect(range[1][0]).toEqual(1)
           expect(range[1][1]).toEqual(41)
+
   describe '::parse', ->
     it 'cries when no argument is passed', ->
       expect ->


### PR DESCRIPTION
some of the linters provides an column of the reported line. 
The helper should support this parameter to avoid refactoring of this lines on each linter plugin.