### PR TITLE
findFile: do not find files in the module dir

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -114,7 +114,7 @@ module.exports = Helpers =
     unless names instanceof Array
       names = [names]
     startDir = startDir.split(path.sep)
-    while startDir.length
+    while startDir.length && startDir.join(path.sep)
       currentDir = startDir.join(path.sep)
       for name in names
         filePath = path.join(currentDir, name)

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -124,6 +124,8 @@ describe 'linter helpers', ->
       .toThrow()
     it 'works', ->
       expect(helpers.findFile(__dirname, 'package.json')).toBe(fs.realpathSync("#{__dirname}/../package.json"))
+    it 'does not find files of the linter module', ->
+      expect(helpers.findFile('/a/path/that/does/not/exist', '.gitignore')).toBe(null)
 
   describe '::exec options', ->
     it 'honors cwd option', ->


### PR DESCRIPTION
Calling `findFile('/a/path/that/does/not/exist', '.gitignore')` located
`.gitignore` of the atom-linter module.

This happened since the first item of `startDir.split(path.sep)` is `""`
and `fs.accessSync('.gitignore', fs.R_OK)` yielded the file from the
module.