### PR TITLE
Check if column start is greater than line length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Upcoming
+
+* Check if column start is greater than line length in `rangeFromLineNumber`
+
 ### 3.3.2
 
 * Fix a bug in Helpers.rangeFromLineNumber

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -58,11 +58,13 @@ module.exports = Helpers =
   rangeFromLineNumber: (textEditor, lineNumber, colStart) ->
     throw new Error('Provided text editor is invalid') unless textEditor?.getText?
     throw new Error('Invalid lineNumber provided') if typeof lineNumber is 'undefined'
+    lineLength = textEditor.getBuffer().lineLengthForRow(lineNumber)
+    throw new Error('Column start greater than line length') if colStart > lineLength
     unless typeof colStart is 'number'
       colStart = (textEditor.indentationForBufferRow(lineNumber) * textEditor.getTabLength())
       if colStart isnt 0
         colStart -= 1
-    colEnd = textEditor.getBuffer().lineLengthForRow(lineNumber)
+    colEnd = lineLength
     if colEnd isnt 0
       colEnd -= 1
     return [

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -99,6 +99,13 @@ describe 'linter helpers', ->
           expect(range[0][1]).toEqual(4)
           expect(range[1][0]).toEqual(1)
           expect(range[1][1]).toEqual(40)
+    it 'cries when colStart is greater than line length', ->
+      waitsForPromise ->
+        atom.workspace.open("#{__dirname}/fixtures/something.js").then ->
+          textEditor = atom.workspace.getActiveTextEditor()
+          expect ->
+            helpers.rangeFromLineNumber(textEditor, 1, 50)
+          .toThrow()
 
   describe '::parse', ->
     it 'cries when no argument is passed', ->


### PR DESCRIPTION
Add a control to rangeFromLineNumber, checking if colStart is a value greater than the length of the line.

See https://github.com/AtomLinter/linter-eslint/issues/276