### PR TITLE
Add helpers.createElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.3.5
+
+* Add Helpers.createElement
+
 ### 3.3.4
 
 * Handle invalid `lineNumber` and return a valid range

--- a/README.md
+++ b/README.md
@@ -15,8 +15,16 @@ class Helpers{
   static rangeFromLineNumber(textEditor: TextEditor, lineNumber: Number):Range
   static findFile(directory:String, names: String | Array<string>)
   static tempFile<T>(filePath:String, fileContents:String, Callback:Function<T>):Promise<T>
+  static createElement(tagName: string): HTMLElement
 }
 ```
+
+#### Explanation for createElement
+
+Linter accepts `HTMLElement`s in the `html` message property. To show the same message on more
+than one DOM Elements, it clones the element. It's a limitation of HTMLElements that they
+lose all the events on clone. If you create your element using `Helpers.createElement` however
+It'll make sure the children inherit the events from the parent.
 
 #### License
 

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -165,3 +165,31 @@ describe 'linter helpers', ->
           return 1
         ).then (result) ->
           expect(result).toBe(1)
+
+  describe '::createElement', ->
+    it 'works', ->
+      clicked = false
+      clickListener = () -> clicked = true
+
+      el = helpers.createElement('div')
+      el.innerHTML = 'Some HTML'
+      expect(el.innerHTML).toBe('Some HTML')
+      el.appendChild(document.createElement('div'))
+      expect(el.children.length).toBe(1)
+
+      el.addEventListener('click', clickListener)
+
+      expect(clicked).toBe(false)
+      el.dispatchEvent(new MouseEvent('click'))
+      expect(clicked).toBe(true)
+
+      clicked = false
+      clonedEl = el.cloneNode(true)
+      clonedEl.dispatchEvent(new MouseEvent('click'))
+      expect(clicked).toBe(true)
+
+      el.removeEventListener('click', clickListener)
+      clicked = false
+      clonedEl = el.cloneNode(true)
+      clonedEl.dispatchEvent(new MouseEvent('click'))
+      expect(clicked).toBe(false)


### PR DESCRIPTION
It'll allow providers to create html elements with events that survive a clone.

Reason:
  We clone the elements in linter because we can't show one element and on both bubble and bottom panel. It'll be removed from the other place if we remove it from one place. As a workaround we clone the given html element and show it there, but that way all the events attached to that element are lost. This will allow package authors to create elements with events that survive a clone

ToDo:
  - [x] Add specs