### PR TITLE
Handle invalid colstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Upcoming
+
+* Handle column start in `rangeFromLineNumber`, when it is greater than line length 
+
 ### 3.3.5
 
 * Add Helpers.createElement

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -60,11 +60,13 @@ module.exports = Helpers =
     throw new Error('Provided text editor is invalid') unless textEditor?.getText?
     if typeof lineNumber is 'undefined' or lineNumber isnt lineNumber
       return [[0, 0], [0, 1]]
+    lineLength = textEditor.getBuffer().lineLengthForRow(lineNumber)
+    throw new Error('Column start greater than line length') if colStart > lineLength
     unless typeof colStart is 'number'
       colStart = (textEditor.indentationForBufferRow(lineNumber) * textEditor.getTabLength())
       if colStart isnt 0
         colStart -= 1
-    colEnd = textEditor.getBuffer().lineLengthForRow(lineNumber)
+    colEnd = lineLength
     if colEnd isnt 0
       colEnd -= 1
     return [

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -97,6 +97,13 @@ describe 'linter helpers', ->
           expect(range[0][1]).toEqual(4)
           expect(range[1][0]).toEqual(1)
           expect(range[1][1]).toEqual(40)
+    it 'cries when colStart is greater than line length', ->
+      waitsForPromise ->
+        atom.workspace.open("#{__dirname}/fixtures/something.js").then ->
+          textEditor = atom.workspace.getActiveTextEditor()
+          expect ->
+            helpers.rangeFromLineNumber(textEditor, 1, 50)
+          .toThrow()
 
   describe '::parse', ->
     it 'cries when no argument is passed', ->


### PR DESCRIPTION
This patch handles colStart when it is greater than line length, throwing an exception.

Another solution may be to set colStart equals to the line length (defensive approach), but I think it is better to warning the programmer the parameter passed is wrong.

(I didn't squash the commits because I made the job via web - I am out of town)