### PR TITLE
Handle mixed indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Upcoming
+
+* Fix `rangeFromLineNumber` on files with mixed indentation
+
 ### 3.3.7
 
 * Force lineNumber in `rangeFromLineNumber` to be within buffer range

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -65,9 +65,11 @@ module.exports = Helpers =
     if lineNumber > maxLine
       throw new Error("Line number (#{lineNumber}) greater than maximum line (#{maxLine})")
     if typeof colStart isnt 'number' or colStart < 0
-      colStart = (textEditor.indentationForBufferRow(lineNumber) * textEditor.getTabLength())
-      if colStart isnt 0
-        colStart -= 1
+      indentation = buffer.lineForRow(lineNumber).match(/^\s+/)
+      if indentation and indentation.length = 1
+        colStart = indentation[0].length
+      else
+        colStart = 0
     lineLength = buffer.lineLengthForRow(lineNumber)
     if colStart > lineLength
       throw new Error("Column start (#{colStart}) greater than line length (#{lineLength})")

--- a/spec/fixtures/mixedIndent.js
+++ b/spec/fixtures/mixedIndent.js
@@ -1,0 +1,4 @@
+foo
+  bar
+	foo
+ 	bar

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -4,7 +4,6 @@ helpers = require '../lib/helpers'
 testFile = __dirname + '/fixtures/test.txt'
 testContents = fs.readFileSync(testFile).toString()
 describe 'linter helpers', ->
-
   describe '::exec*', ->
     it 'cries when no argument is passed', ->
       expect( -> helpers.exec()).toThrow()
@@ -29,7 +28,11 @@ describe 'linter helpers', ->
           expect(data.stderr).toBe('STDERR')
     it 'accepts stdin', ->
       waitsForPromise ->
-        helpers.execNode("#{__dirname}/fixtures/something.js", ['input'], {stream: 'stdout', stdin: 'Wow'}).then (data) ->
+        helpers.execNode(
+          "#{__dirname}/fixtures/something.js",
+          ['input'],
+          {stream: 'stdout', stdin: 'Wow'}
+        ).then (data) ->
           expect(data).toBe('STDOUTWow')
       waitsForPromise ->
         helpers.exec('cat', [], stream: 'stdout', stdin: testContents).then (text) ->
@@ -119,6 +122,14 @@ describe 'linter helpers', ->
           expect ->
             helpers.rangeFromLineNumber(textEditor, 8)
           .toThrow()
+    it 'handles files with mixed intentation', ->
+      waitsForPromise ->
+        atom.workspace.open("#{__dirname}/fixtures/mixedIndent.js").then ->
+          textEditor = atom.workspace.getActiveTextEditor()
+          expect(helpers.rangeFromLineNumber(textEditor, 0)).toEqual([[0, 0], [0, 2]])  # None
+          expect(helpers.rangeFromLineNumber(textEditor, 1)).toEqual([[1, 2], [1, 4]])  # Spaces
+          expect(helpers.rangeFromLineNumber(textEditor, 2)).toEqual([[2, 1], [2, 3]])  # Tabs
+          expect(helpers.rangeFromLineNumber(textEditor, 3)).toEqual([[3, 2], [3, 4]])  # Mixed
 
   describe '::parse', ->
     it 'cries when no argument is passed', ->


### PR DESCRIPTION
Previously it was assumed that a file had consistent indentation, this fixes that incorrect assumption.

Fixes #63.