### PR TITLE
Fix the range end point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Upcoming
+
+* Revert the changes in 3.3.2, `Range()`'s end point is exclusive, not inclusive.
+
 ### 3.3.8
 
 * Fix `rangeFromLineNumber` on files with mixed indentation

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -73,12 +73,9 @@ module.exports = Helpers =
     lineLength = buffer.lineLengthForRow(lineNumber)
     if colStart > lineLength
       throw new Error("Column start (#{colStart}) greater than line length (#{lineLength})")
-    colEnd = lineLength
-    if colEnd isnt 0
-      colEnd -= 1
     return [
       [lineNumber, colStart],
-      [lineNumber, colEnd]
+      [lineNumber, lineLength]
     ]
 
   createElement: (name) ->

--- a/spec/helper-spec.coffee
+++ b/spec/helper-spec.coffee
@@ -82,8 +82,8 @@ describe 'linter helpers', ->
       waitsForPromise ->
         atom.workspace.open("#{__dirname}/fixtures/something.js").then ->
           textEditor = atom.workspace.getActiveTextEditor()
-          expect(helpers.rangeFromLineNumber(textEditor, 1, -1)).toEqual([[1, 0], [1, 40]])
-          expect(helpers.rangeFromLineNumber(textEditor, 1, 'a')).toEqual([[1, 0], [1, 40]])
+          expect(helpers.rangeFromLineNumber(textEditor, 1, -1)).toEqual([[1, 0], [1, 41]])
+          expect(helpers.rangeFromLineNumber(textEditor, 1, 'a')).toEqual([[1, 0], [1, 41]])
     it 'returns a range (array) with some valid points', ->
       waitsForPromise ->
         atom.workspace.open("#{__dirname}/fixtures/something.js").then ->
@@ -95,7 +95,7 @@ describe 'linter helpers', ->
           expect(range[0][0]).toEqual(1)
           expect(range[0][1]).toEqual(0)
           expect(range[1][0]).toEqual(1)
-          expect(range[1][1]).toEqual(40)
+          expect(range[1][1]).toEqual(41)
     it 'returns a range (array) with some valid points and provided colStart', ->
       waitsForPromise ->
         atom.workspace.open("#{__dirname}/fixtures/something.js").then ->
@@ -107,7 +107,7 @@ describe 'linter helpers', ->
           expect(range[0][0]).toEqual(1)
           expect(range[0][1]).toEqual(4)
           expect(range[1][0]).toEqual(1)
-          expect(range[1][1]).toEqual(40)
+          expect(range[1][1]).toEqual(41)
     it 'cries when colStart is greater than line length', ->
       waitsForPromise ->
         atom.workspace.open("#{__dirname}/fixtures/something.js").then ->
@@ -126,10 +126,10 @@ describe 'linter helpers', ->
       waitsForPromise ->
         atom.workspace.open("#{__dirname}/fixtures/mixedIndent.js").then ->
           textEditor = atom.workspace.getActiveTextEditor()
-          expect(helpers.rangeFromLineNumber(textEditor, 0)).toEqual([[0, 0], [0, 2]])  # None
-          expect(helpers.rangeFromLineNumber(textEditor, 1)).toEqual([[1, 2], [1, 4]])  # Spaces
-          expect(helpers.rangeFromLineNumber(textEditor, 2)).toEqual([[2, 1], [2, 3]])  # Tabs
-          expect(helpers.rangeFromLineNumber(textEditor, 3)).toEqual([[3, 2], [3, 4]])  # Mixed
+          expect(helpers.rangeFromLineNumber(textEditor, 0)).toEqual([[0, 0], [0, 3]])  # None
+          expect(helpers.rangeFromLineNumber(textEditor, 1)).toEqual([[1, 2], [1, 5]])  # Spaces
+          expect(helpers.rangeFromLineNumber(textEditor, 2)).toEqual([[2, 1], [2, 4]])  # Tabs
+          expect(helpers.rangeFromLineNumber(textEditor, 3)).toEqual([[3, 2], [3, 5]])  # Mixed
 
   describe '::parse', ->
     it 'cries when no argument is passed', ->


### PR DESCRIPTION
Turns out that the Range() end point is exclusive, not inclusive as was previously assumed.