### PR TITLE
Rename findFile$ to find$

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Upcoming
+
+* Rename `Helpers.findFile$` to `Helpers.find$` (also exported with previous names for backward compatibility)
+
 ### 3.4.0
 
 * Add `Helpers.findFileAsync`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,12 +4,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.findFileAsync = exports.findFile = undefined;
 exports.exec = exec;
 exports.execNode = execNode;
 exports.rangeFromLineNumber = rangeFromLineNumber;
 exports.createElement = createElement;
-exports.findFileAsync = findFileAsync;
-exports.findFile = findFile;
+exports.findAsync = findAsync;
+exports.find = find;
 exports.tempFile = tempFile;
 exports.parse = parse;
 
@@ -197,7 +198,7 @@ function createElement(name) {
   return element;
 }
 
-function findFileAsync(directory, name) {
+function findAsync(directory, name) {
   validate_find(directory, name);
   const names = name instanceof Array ? name : [name];
   const chunks = directory.split(_path2.default.sep);
@@ -234,7 +235,7 @@ function findFileAsync(directory, name) {
   return promise;
 }
 
-function findFile(directory, name) {
+function find(directory, name) {
   validate_find(directory, name);
   const names = name instanceof Array ? name : [name];
   const chunks = directory.split(_path2.default.sep);
@@ -347,4 +348,7 @@ function parse(data, regex) {
 
   return messages;
 }
+
+exports.findFile = find;
+exports.findFileAsync = findAsync;
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -166,7 +166,7 @@ export function createElement(name) {
   return element
 }
 
-export function findFileAsync(directory, name) {
+export function findAsync(directory, name) {
   validate_find(directory, name)
   const names = name instanceof Array ? name : [name]
   const chunks = directory.split(Path.sep)
@@ -203,7 +203,7 @@ export function findFileAsync(directory, name) {
   return promise
 }
 
-export function findFile(directory, name) {
+export function find(directory, name) {
   validate_find(directory, name)
   const names = name instanceof Array ? name : [name]
   const chunks = directory.split(Path.sep)
@@ -317,3 +317,5 @@ export function parse(data, regex, opts = {}) {
 
   return messages
 }
+
+export {find as findFile, findAsync as findFileAsync}


### PR DESCRIPTION
#### Why

Because it never really looked for just files, it looks for anything with that name that's readable

#### Is is backward compatible

We still export the previous functions as aliases to new ones, so Yes that's backward compatible

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atom-linter/68)
<!-- Reviewable:end -->
