### PR TITLE
Check root dir

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -204,9 +204,9 @@ function findFileAsync(directory, name) {
   let promise = Promise.resolve(null);
 
   while (chunks.length) {
-    const currentDir = chunks.join(_path2.default.sep);
+    let currentDir = chunks.join(_path2.default.sep);
     if (currentDir === '') {
-      break;
+      currentDir = _path2.default.resolve(directory, '/');
     }
     promise = promise.then(function (filePath) {
       if (filePath !== null) {
@@ -240,9 +240,9 @@ function findFile(directory, name) {
   const chunks = directory.split(_path2.default.sep);
 
   while (chunks.length) {
-    const currentDir = chunks.join(_path2.default.sep);
+    let currentDir = chunks.join(_path2.default.sep);
     if (currentDir === '') {
-      break;
+      currentDir = _path2.default.resolve(directory, '/');
     }
     for (const fileName of names) {
       const filePath = _path2.default.join(currentDir, fileName);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -173,9 +173,9 @@ export function findFileAsync(directory, name) {
   let promise = Promise.resolve(null)
 
   while (chunks.length) {
-    const currentDir = chunks.join(Path.sep)
+    let currentDir = chunks.join(Path.sep)
     if (currentDir === '') {
-      break
+      currentDir = Path.resolve(directory, '/')
     }
     promise = promise.then(function(filePath) {
       if (filePath !== null) {
@@ -209,9 +209,9 @@ export function findFile(directory, name) {
   const chunks = directory.split(Path.sep)
 
   while (chunks.length) {
-    const currentDir = chunks.join(Path.sep)
+    let currentDir = chunks.join(Path.sep)
     if (currentDir === '') {
-      break
+      currentDir = Path.resolve(directory, '/')
     }
     for (const fileName of names) {
       const filePath = Path.join(currentDir, fileName)


### PR DESCRIPTION
If an absolute path (e.g. `/foo/bar`) is given to the current implementation of `findFile`, the root directory is stripped out and will not be checked.  Rather, it checks:

- `/foo/bar`
- `/foo`

The changes in this PR should cause it to check:

- `/foo/bar`
- `/foo`
- `/`