### PR TITLE
Use named-js-regexp instead of xregexp

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -34,7 +34,7 @@ var _consistentPath = require('consistent-path');
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
-let XRegExp = null;
+let NamedRegexp = null;
 const FindCache = exports.FindCache = new Map();
 
 // TODO: Remove this when electron upgrades node
@@ -246,14 +246,36 @@ function find(directory, name) {
     if (currentDir === '') {
       currentDir = Path.resolve(directory, '/');
     }
-    for (const fileName of names) {
-      const filePath = Path.join(currentDir, fileName);
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
 
+    try {
+      for (var _iterator = names[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        const fileName = _step.value;
+
+        const filePath = Path.join(currentDir, fileName);
+
+        try {
+          FS.accessSync(filePath, FS.R_OK);
+          return filePath;
+        } catch (_) {}
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
       try {
-        FS.accessSync(filePath, FS.R_OK);
-        return filePath;
-      } catch (_) {}
+        if (!_iteratorNormalCompletion && _iterator.return) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
     }
+
     chunks.pop();
   }
 
@@ -361,17 +383,19 @@ function parse(data, regex) {
     throw new Error('Invalid or no `options` provided');
   }
 
-  if (XRegExp === null) {
-    XRegExp = require('xregexp').XRegExp;
+  if (NamedRegexp === null) {
+    NamedRegexp = require('named-js-regexp');
   }
 
-  const messages = [];
-  const options = assign({
-    flags: 'g'
-  }, opts);
-  const xregex = XRegExp(regex, options.flags);
+  const options = assign({ flags: '' }, opts);
+  options.flags += 'g';
 
-  XRegExp.forEach(data, xregex, function (match) {
+  const messages = [];
+  const compiledRegexp = NamedRegexp(regex, options.flags);
+  let rawMatch = null;
+
+  while ((rawMatch = compiledRegexp.exec(data)) !== null) {
+    const match = rawMatch.groups();
     const type = match.type;
     const text = match.message;
     const file = match.file || options.filePath || null;
@@ -387,7 +411,7 @@ function parse(data, regex) {
       filePath: file,
       range: [[lineStart > 0 ? lineStart - 1 : 0, colStart > 0 ? colStart - 1 : 0], [lineEnd > 0 ? lineEnd - 1 : 0, colEnd > 0 ? colEnd - 1 : 0]]
     });
-  });
+  }
 
   return messages;
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "homepage": "https://github.com/AtomLinter/atom-linter#readme",
   "dependencies": {
-    "xregexp": "^3.0.0",
-    "tmp": "latest",
-    "consistent-path": "^1.0.3"
+    "consistent-path": "^1.0.3",
+    "named-js-regexp": "^1.3.1",
+    "tmp": "latest"
   },
   "devDependencies": {
     "babel-preset-steelbrain": "^1.0.0"

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,7 +6,7 @@ import * as FS from 'fs'
 import * as TMP from 'tmp'
 import {getPath} from 'consistent-path'
 
-let XRegExp = null
+let NamedRegexp = null
 export const FindCache = new Map()
 
 // TODO: Remove this when electron upgrades node
@@ -327,17 +327,19 @@ export function parse(data, regex, opts = {}) {
     throw new Error('Invalid or no `options` provided')
   }
 
-  if (XRegExp === null) {
-    XRegExp = require('xregexp').XRegExp
+  if (NamedRegexp === null) {
+    NamedRegexp = require('named-js-regexp')
   }
 
-  const messages = []
-  const options = assign({
-    flags: 'g'
-  }, opts)
-  const xregex = XRegExp(regex, options.flags)
+  const options = assign({flags: ''}, opts)
+  options.flags += 'g'
 
-  XRegExp.forEach(data, xregex, function(match) {
+  const messages = []
+  const compiledRegexp = NamedRegexp(regex, options.flags)
+  let rawMatch = null
+
+  while ((rawMatch = compiledRegexp.exec(data)) !== null) {
+    const match = rawMatch.groups()
     const type = match.type
     const text = match.message
     const file = match.file || options.filePath || null
@@ -356,7 +358,7 @@ export function parse(data, regex, opts = {}) {
         [lineEnd > 0 ? lineEnd - 1 : 0, colEnd > 0 ? colEnd - 1 : 0],
       ]
     })
-  })
+  }
 
   return messages
 }


### PR DESCRIPTION
cc @Arcanemagus 

Pros
 - It's backward compatible
 - It's lightweight, so the tons of packages depending on this package that don't use it will enjoy it

Cons
 - Not yet battle tested on our scale (it does have a test suite)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/atom-linter/98)
<!-- Reviewable:end -->
