### PR TITLE
Return whole first line on error

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -147,13 +147,14 @@ function execNode(command) {
   return _exec(command, args, options, true);
 }
 
-function rangeFromLineNumber(textEditor, lineNumber, column) {
+function rangeFromLineNumber(textEditor, line, column) {
   if (typeof textEditor.getText !== 'function') {
     throw new Error('Invalid textEditor provided');
   }
+  let lineNumber = line;
 
   if (!Number.isFinite(lineNumber) || Number.isNaN(lineNumber) || lineNumber < 0) {
-    return [[0, 0], [0, 1]];
+    lineNumber = 0;
   }
 
   const buffer = textEditor.getBuffer();

--- a/spec/helper-spec.js
+++ b/spec/helper-spec.js
@@ -147,9 +147,9 @@ describe('linter helpers', () => {
       waitsForPromise(() =>
         atom.workspace.open(somethingFile).then(() => {
           const textEditor = atom.workspace.getActiveTextEditor()
-          expect(helpers.rangeFromLineNumber(textEditor)).toEqual([[0, 0], [0, 1]])
-          expect(helpers.rangeFromLineNumber(textEditor, -1)).toEqual([[0, 0], [0, 1]])
-          return expect(helpers.rangeFromLineNumber(textEditor, 'a')).toEqual([[0, 0], [0, 1]])
+          expect(helpers.rangeFromLineNumber(textEditor)).toEqual([[0, 0], [0, 30]])
+          expect(helpers.rangeFromLineNumber(textEditor, -1)).toEqual([[0, 0], [0, 30]])
+          return expect(helpers.rangeFromLineNumber(textEditor, 'a')).toEqual([[0, 0], [0, 30]])
         })
       )
     )

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -116,13 +116,14 @@ export function execNode(command, args = [], options = {}) {
   return _exec(command, args, options, true)
 }
 
-export function rangeFromLineNumber(textEditor, lineNumber, column) {
+export function rangeFromLineNumber(textEditor, line, column) {
   if (typeof textEditor.getText !== 'function') {
     throw new Error('Invalid textEditor provided')
   }
+  let lineNumber = line
 
   if (!Number.isFinite(lineNumber) || Number.isNaN(lineNumber) || lineNumber < 0) {
-    return [[0, 0], [0, 1]]
+    lineNumber = 0
   }
 
   const buffer = textEditor.getBuffer()


### PR DESCRIPTION
When an invalid or no line number is given, return the entire first line instead of just the first character.

Fixes #87.