### PR TITLE
Use the Atom API to validate TextEditor

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -131,6 +131,19 @@ function _validateFind(directory, name) {
   }
 }
 
+function _validateEditor(editor) {
+  let isEditor;
+  if (typeof atom.workspace.isTextEditor === 'function') {
+    // Added in Atom v1.4.0
+    isEditor = atom.workspace.isTextEditor(editor);
+  } else {
+    isEditor = typeof editor.getText !== 'function';
+  }
+  if (!isEditor) {
+    throw new Error('Invalid TextEditor provided');
+  }
+}
+
 function exec(command) {
   let args = arguments.length <= 1 || arguments[1] === undefined ? [] : arguments[1];
   let options = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
@@ -148,9 +161,7 @@ function execNode(command) {
 }
 
 function rangeFromLineNumber(textEditor, line, column) {
-  if (typeof textEditor.getText !== 'function') {
-    throw new Error('Invalid textEditor provided');
-  }
+  _validateEditor(textEditor);
   let lineNumber = line;
 
   if (!Number.isFinite(lineNumber) || Number.isNaN(lineNumber) || lineNumber < 0) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -106,6 +106,19 @@ function _validateFind(directory, name) {
   }
 }
 
+function _validateEditor(editor) {
+  let isEditor
+  if (typeof atom.workspace.isTextEditor === 'function') {
+    // Added in Atom v1.4.0
+    isEditor = atom.workspace.isTextEditor(editor)
+  } else {
+    isEditor = typeof editor.getText !== 'function'
+  }
+  if (!isEditor) {
+    throw new Error('Invalid TextEditor provided')
+  }
+}
+
 export function exec(command, args = [], options = {}) {
   _validateExec(command, args, options)
   return _exec(command, args, options, false)
@@ -117,9 +130,7 @@ export function execNode(command, args = [], options = {}) {
 }
 
 export function rangeFromLineNumber(textEditor, line, column) {
-  if (typeof textEditor.getText !== 'function') {
-    throw new Error('Invalid textEditor provided')
-  }
+  _validateEditor(textEditor)
   let lineNumber = line
 
   if (!Number.isFinite(lineNumber) || Number.isNaN(lineNumber) || lineNumber < 0) {


### PR DESCRIPTION
As of Atom v1.4.0 there is a built in function to validate whether an object is a TextEditor, move to using that if available.

Fixes #80.