### PR TITLE
Use consistent-env instead of consistent-path

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  presets: ["steelbrain"]
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Upcoming
+
+*   Use `consistent-env` instead of `consistent-path`
+
 ## 4.5.1
 
 *   Fix for runtimes which don't have the `atom` module

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/AtomLinter/atom-linter#readme",
   "dependencies": {
-    "consistent-env": "^1.0.0",
+    "consistent-env": "^1.0.1",
     "named-js-regexp": "^1.3.1",
     "sb-promisify": "^1.0.0",
     "tmp": "~0.0.28"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/AtomLinter/atom-linter#readme",
   "dependencies": {
-    "consistent-path": "^1.0.3",
+    "consistent-env": "^1.0.0",
     "named-js-regexp": "^1.3.1",
     "sb-promisify": "^1.0.0",
     "tmp": "~0.0.28"

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -94,7 +94,7 @@ export function exec(
     throwOnStdErr: true
   }, opts)
 
-  options.env = Object.assign(consistentEnv(), options.env)
+  options.env = assign(consistentEnv(), options.env)
   if (isNode && options.env) {
     delete options.env.OS
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -82,7 +82,7 @@ export function validateFind(directory: string, name: string | Array<string>) {
   }
 }
 
-export function exec(
+export async function exec(
   command: string,
   args: Array<string>,
   opts: ExecOptions,
@@ -94,12 +94,12 @@ export function exec(
     throwOnStdErr: true
   }, opts)
 
-  options.env = assign(consistentEnv(), options.env)
+  options.env = assign(await consistentEnv.async(), options.env)
   if (isNode && options.env.OS) {
     delete options.env.OS
   }
 
-  return new Promise(function (resolve, reject) {
+  return await new Promise(function (resolve, reject) {
     const data = { stdout: [], stderr: [] }
     const handleError = function (error) {
       if (error && error.code === 'EACCES' ||

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,7 +5,7 @@
 import FS from 'fs'
 import Temp from 'tmp'
 import promisify from 'sb-promisify'
-import { getPath } from 'consistent-path'
+import consistentEnv from 'consistent-env'
 import type { TextEditor } from 'atom'
 import type { TempDirectory, ExecResult, ExecOptions } from './types'
 
@@ -89,15 +89,15 @@ export function exec(
   isNode: boolean
 ): Promise<ExecResult> {
   const options: ExecOptions = assign({
-    env: assign({}, process.env),
+    env: {},
     stream: 'stdout',
     throwOnStdErr: true
   }, opts)
 
+  options.env = Object.assign(consistentEnv(), options.env)
   if (isNode && options.env) {
     delete options.env.OS
   }
-  assign(options.env, { PATH: getPath() })
 
   return new Promise(function (resolve, reject) {
     const data = { stdout: [], stderr: [] }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -95,7 +95,7 @@ export function exec(
   }, opts)
 
   options.env = assign(consistentEnv(), options.env)
-  if (isNode && options.env) {
+  if (isNode && options.env.OS) {
     delete options.env.OS
   }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -89,12 +89,11 @@ export async function exec(
   isNode: boolean
 ): Promise<ExecResult> {
   const options: ExecOptions = assign({
-    env: {},
+    env: await consistentEnv.async(),
     stream: 'stdout',
     throwOnStdErr: true
   }, opts)
 
-  options.env = assign(await consistentEnv.async(), options.env)
   if (isNode && options.env.OS) {
     delete options.env.OS
   }


### PR DESCRIPTION
We will not just be figuring out the `PATH` but all the tokens of keys or configurations the user might have set for applications in their rc files